### PR TITLE
Fixes #51 error when missing field_image

### DIFF
--- a/metatag_opengraph/metatag_opengraph.module
+++ b/metatag_opengraph/metatag_opengraph.module
@@ -46,8 +46,8 @@ function metatag_opengraph_metatag_bundled_config_alter(array &$configs) {
             'og:description' => array('value' => '[node:summary]'),
             'og:title' => array('value' => '[node:title]'),
             'og:updated_time' => array('value' => '[node:changed:custom:c]'),
-            'og:image' => array('value' => '[node:field_image]'),
-            'og:image:url' => array('value' => '[node:field_image]'),
+            // 'og:image' => array('value' => '[node:field_image]'),
+            // 'og:image:url' => array('value' => '[node:field_image]'),
           );
           break;
 


### PR DESCRIPTION
opengraph submodule put [node:field_image] as default token to image and image url settings, even if its not set in the system. I know that backdrop ships with this field, but it might be deleted or changed. In that case, the settings form always fill in the default value, and thus fails, every time you update it.

I propose to not provide that default, as anyway, this is a very customizable module and you have to set it anyway

Fixes https://github.com/backdrop-contrib/metatag/issues/51