### PR TITLE
Issue #58: Fix failing favicon functionality and test

### DIFF
--- a/metatag_favicons/metatag_favicons.module
+++ b/metatag_favicons/metatag_favicons.module
@@ -76,14 +76,9 @@ function theme_metatag_shortcut_icon($variables) {
  *  The absolute URL to the favicon, empty string if not found.
  */
 function metatag_favicons_get_theme_favicon() {
-  $favicon_url = '';
+  $favicon = backdrop_get_favicon();
 
-  // Is the favicon enabled?
-  if (theme_get_setting('toggle_favicon')) {
-    $favicon_url = theme_get_setting('favicon');
-  }
-
-  return $favicon_url;
+  return url($favicon['path'], array('absolute' => TRUE));
 }
 
 /**


### PR DESCRIPTION
Related to https://github.com/backdrop-contrib/metatag/issues/58

Note: the output caching problem is still pending.