### PR TITLE
Issue #89: Add quicksketch as maintainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Current Maintainers
 -------------------
 
 - Jen Lampton (https://github.com/jenlampton).
+- Nate Lampton (https://github.com/quicksketch).
 - Seeking additional maintainers.
 
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/metatag/issues/89