### PR TITLE
Issue #70: Fix renamed 'language' to 'langcode' property.

### DIFF
--- a/metatag_devel/metatag_devel.module
+++ b/metatag_devel/metatag_devel.module
@@ -181,7 +181,7 @@ function metatag_devel_node_insert($node) {
 
     // Adjust the values for the nested language structure.
     $metatags = array(
-      $node->language => $metatags,
+      $node->langcode => $metatags,
     );
 
     // Save the meta tags.

--- a/metatag_google_plus/README.txt
+++ b/metatag_google_plus/README.txt
@@ -29,7 +29,7 @@ file being used on the site, and it must be added after the $rdf_namespaces
 variable, e.g.:
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php print
-  $language->language; ?>" version="XHTML+RDFa 1.0" dir="<?php print
+  $language->langcode; ?>" version="XHTML+RDFa 1.0" dir="<?php print
   $language->dir; ?>"<?php print $rdf_namespaces; ?><?php print $schemaorg; ?>>
 
 

--- a/metatag_hreflang/tests/metatag_hreflang.with_entity_translation.test
+++ b/metatag_hreflang/tests/metatag_hreflang.with_entity_translation.test
@@ -164,10 +164,9 @@ class MetatagHreflangWithEntityTranslationTest extends MetatagTestHelper {
       }
 
       // Confirm that a link to translate the node into each locale exists.
-      $url = 'node/' . $node->nid . '/edit/add/' . $node->language . '/' . $langcode;
+      $url = 'node/' . $node->nid . '/edit/add/' . $node->langcode . '/' . $langcode;
       $urls[$langcode] = $url;
-      // @todo This fails in testbot.
-      // $this->assertLinkbyHref(url($url));
+      $this->assertLinkbyHref(url($url));
     }
 
     // Check each of the 'translate' pages loads properly.
@@ -235,7 +234,7 @@ class MetatagHreflangWithEntityTranslationTest extends MetatagTestHelper {
 
       // The node's default language should not have been found, it should have
       // been turned into an xdefault.
-      if ($langcode == $node->language) {
+      if ($langcode == $node->langcode) {
         $this->assertFalse((bool)$found, format_string("A regular hreflang meta tag for the node's default language (%lang) was not found.", array('%lang' => $langcode)));
       }
 
@@ -265,13 +264,13 @@ class MetatagHreflangWithEntityTranslationTest extends MetatagTestHelper {
     $this->assertEqual(count($xpath), count($locales) + 1, 'The correct number of hreflang meta tags was found.');
     $found = FALSE;
     foreach ($xpath as $ctr => $item) {
-      if ($item['hreflang'] == $node->language) {
+      if ($item['hreflang'] == $node->langcode) {
         $found = $ctr;
       }
     }
     $this->assertTrue((bool)$found, "Found an hreflang meta tag for the node's default locale.");
     if ($found) {
-      $this->assertEqual($xpath[$found]['hreflang'], $node->language);
+      $this->assertEqual($xpath[$found]['hreflang'], $node->langcode);
     }
   }
 

--- a/metatag_views/metatag_views.module
+++ b/metatag_views/metatag_views.module
@@ -114,7 +114,7 @@ function metatag_views_preprocess_page(&$variables) {
       // Build options for meta tag rendering.
       $options = array();
       $options['token data']['view'] = $view;
-      $options['language'] = $language->language;
+      $options['language'] = $language->langcode;
 
       // Add the metatags.
       $processed_metatags = metatag_metatags_view($instance, $metatags, $options);

--- a/metatag_views/metatag_views.tokens.inc
+++ b/metatag_views/metatag_views.tokens.inc
@@ -55,7 +55,7 @@ function metatag_views_tokens($type, $tokens, array $data = array(), array $opti
     $url_options['language'] = $options['language'];
   }
   $sanitize = !empty($options['sanitize']);
-  $langcode = isset($options['language']) ? $options['language']->language : NULL;
+  $langcode = isset($options['language']) ? $options['language']->langcode : NULL;
 
   $replacements = array();
 

--- a/tests/metatag.bulk_revert.test
+++ b/tests/metatag.bulk_revert.test
@@ -43,7 +43,7 @@ class MetatagBulkRevertTest extends MetatagTestHelper {
     // Confirm each of the languages has a checkbox.
     $this->assertFieldByName("languages[" . LANGUAGE_NONE . "]");
     foreach (language_list() as $language) {
-      $this->assertFieldByName("languages[{$language->language}]");
+      $this->assertFieldByName("languages[{$language->langcode}]");
     }
   }
 

--- a/tests/metatag.helper.test
+++ b/tests/metatag.helper.test
@@ -31,6 +31,9 @@ abstract class MetatagTestHelper extends BackdropWebTestCase {
     $modules[] = 'metatag_test';
 
     parent::setUp($modules);
+
+    // Enable the "Abstract" field for testing.
+    config_set('metatag.settings', 'enabled_tags.abstract', 'abstract');
   }
 
   /**

--- a/tests/metatag.locale.test
+++ b/tests/metatag.locale.test
@@ -133,7 +133,7 @@ class MetatagCoreLocaleTest extends MetatagTestHelper {
 
     // Create a test node.
     $node = $this->drupalCreateNode();
-    $this->assertEqual($node->language, LANGUAGE_NONE);
+    $this->assertEqual($node->langcode, LANGUAGE_NONE);
 
     // Load the node page, confirm that the "content-language" meta tag is not
     // output.


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/metatag/issues/70.