### PR TITLE
Issue #92: Fix incorrect caching of enabled tags and test failures.

### DIFF
--- a/metatag.module
+++ b/metatag.module
@@ -1984,14 +1984,19 @@ function metatag_get_info($type = NULL, $name = NULL, $include_disabled = FALSE)
   // Use the advanced backdrop_static() pattern, since this is called very often.
   static $backdrop_static_fast;
   if (!isset($backdrop_static_fast)) {
-    $backdrop_static_fast['metatag_info'] = &backdrop_static(__FUNCTION__);
+    $backdrop_static_fast['metatag_info'] = &backdrop_static(__FUNCTION__, array(
+      'all' => NULL,
+      'enabled' => NULL,
+    ));
   }
-  $info = &$backdrop_static_fast['metatag_info'];
+  // Two static lists are stored: the complete list and the enabled-only list.
+  $info = &$backdrop_static_fast['metatag_info']['all'];
+  $info_enabled = &$backdrop_static_fast['metatag_info']['enabled'];
 
   global $language;
   if (!isset($info)) {
-    // hook_metatag_info() includes translated strings, so each language is cached
-    // separately.
+    // hook_metatag_info() includes translated strings, so each language is
+    // cached separately.
     $cid = 'info:' . $language->langcode;
 
     if ($cache = metatag_cache_get($cid)) {
@@ -2003,18 +2008,12 @@ function metatag_get_info($type = NULL, $name = NULL, $include_disabled = FALSE)
       $info = module_invoke_all('metatag_info');
       $info += array('tags' => array(), 'groups' => array());
 
-      $enabled = config_get('metatag.settings', 'enabled_tags');
       foreach ($info['tags'] as $key => $data) {
         // Merge in default values.
         $info['tags'][$key] += array(
           'name' => $key,
           'class' => 'BackdropTextMetaTag',
         );
-
-        // Only show enabled tags.
-        if (empty($enabled[$key]) && !$include_disabled) {
-          unset($info['tags'][$key]);
-        }
       }
 
       // Let other modules alter the entity info using
@@ -2023,16 +2022,41 @@ function metatag_get_info($type = NULL, $name = NULL, $include_disabled = FALSE)
 
       metatag_cache_set($cid, $info);
     }
+
+    // Build separate list of only enabled tags.
+    if (!isset($info_enabled)) {
+      $info_enabled = $info;
+
+      $enabled_tags = array_filter(config_get('metatag.settings', 'enabled_tags'));
+      $info_enabled['tags'] = array_intersect_key($info['tags'], $enabled_tags);
+
+      // Filter down the list of groups to only those that have active tags.
+      $enabled_groups = array();
+      foreach ($info_enabled['tags'] as $tag_info) {
+        $group = $tag_info['group'];
+        if (!isset($enabled_groups[$group])) {
+          $enabled_groups[$group] = TRUE;
+        }
+        $info_enabled['groups'] = array_intersect_key($info['groups'], $enabled_groups);
+      }
+    }
+  }
+
+  if ($include_disabled) {
+    $return_info = $info;
+  }
+  else {
+    $return_info = $info_enabled;
   }
 
   if (isset($type) && isset($name)) {
-    return isset($info[$type][$name]) ? $info[$type][$name] : FALSE;
+    return isset($return_info[$type][$name]) ? $return_info[$type][$name] : FALSE;
   }
   elseif (isset($type)) {
-    return isset($info[$type]) ? $info[$type] : array();
+    return isset($return_info[$type]) ? $return_info[$type] : array();
   }
   else {
-    return $info;
+    return $return_info;
   }
 }
 

--- a/metatag_favicons/metatag_favicons.mask-icon.class.inc
+++ b/metatag_favicons/metatag_favicons.mask-icon.class.inc
@@ -90,6 +90,11 @@ class BackdropMaskIconMetaTag extends BackdropTextMetaTag {
       '#weight' => $this->getWeight(),
     );
 
+    // Remove the color attribute if empty.
+    if (empty($color)) {
+      unset($element['#attributes']['color']);
+    }
+
     return $element;
   }
 

--- a/metatag_favicons/tests/metatag_favicons.test
+++ b/metatag_favicons/tests/metatag_favicons.test
@@ -17,6 +17,9 @@ class MetatagFaviconsTest extends MetatagTestHelper {
     // Create an admin user and log them in.
     $this->adminUser = $this->createAdminUser();
     $this->backdropLogin($this->adminUser);
+
+    // Enable mask icon metatag used in these tests.
+    config_set('metatag.settings', 'enabled_tags.mask-icon', 'generator');
   }
 
   /**
@@ -198,13 +201,16 @@ class MetatagFaviconsTest extends MetatagTestHelper {
     $this->assertEqual((string)$xpath[0]['href'], $absolute_path);
     $this->assertEqual((string)$xpath[0]['color'], $color2);
 
+    // Before proceeding, clear the site's caches.
+    backdrop_flush_all_caches();
+
     // Try empty color.
     $color = '';
 
     // Update the global config.
     $config = metatag_config_load('global');
-    $config->config['mask-icon']['value'] = $svg_path;
-    $config->config['mask-icon']['color'] = $color;
+    $config['config']['mask-icon']['value'] = $svg_path;
+    $config['config']['mask-icon']['color'] = $color;
     metatag_config_save($config);
 
     // Load the front page.

--- a/tests/metatag.core_tag_removal.test
+++ b/tests/metatag.core_tag_removal.test
@@ -10,6 +10,10 @@ class MetatagCoreTagRemovalTest extends MetatagTestHelper {
    * Test that the core meta tags work correctly.
    */
   function testCoreTagRemoval() {
+    // Enable core tags and the generator override.
+    config_set('metatag.settings', 'enabled_tags.generator', 'generator');
+    config_set('metatag.settings', 'leave_core_tags', TRUE);
+
     // The default generator string that both Metatag and backdrop core use.
     $generator_global = 'Backdrop CMS (http://backdropcms.org)';
     $generator_core = 'Backdrop CMS 1 (https://backdropcms.org)';

--- a/tests/metatag.tags.test
+++ b/tests/metatag.tags.test
@@ -20,6 +20,15 @@ class MetatagTagsTestBase extends MetatagTestHelper {
     // Create an admin user that can manage meta tags.
     $account = $this->createAdminUser();
     $this->backdropLogin($account);
+
+    // Ensure any tested tags are enabled at the start.
+    $config = config('metatag.settings');
+    $enabled_tags = $config->get('enabled_tags');
+    foreach ($this->tags as $tag_name) {
+      $enabled_tags[$tag_name] = $tag_name;
+    }
+    $config->set('enabled_tags', $enabled_tags);
+    $config->save();
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/metatag/issues/92.