### PR TITLE
Issue #64: Move MetatagSearchTestSearchApiService to dedicated file.

### DIFF
--- a/tests/metatag.with_search_api.test
+++ b/tests/metatag.with_search_api.test
@@ -63,7 +63,7 @@ class MetatagCoreWithSearchAPITest extends MetatagTestHelper {
       'administer search_api',
     );
     $this->adminUser = $this->createAdminUser($perms);
-    $this->drupalLogin($this->adminUser);
+    $this->backdropLogin($this->adminUser);
 
     // Create an index.
     $this->indexId = 'test_index';
@@ -97,16 +97,16 @@ class MetatagCoreWithSearchAPITest extends MetatagTestHelper {
       'description' => 'A server used for testing.',
       'class' => 'metatag_search_test_service',
     );
-    $this->drupalPost('admin/config/search/search_api/add_server', $values, 'Create server');
+    $this->backdropPost('admin/config/search/search_api/add_server', $values, 'Create server');
 
     // Configure the server.
-    $this->drupalPost(NULL, array(), 'Create server');
+    $this->backdropPost(NULL, array(), 'Create server');
     $this->assertText(t('The server was successfully created.'));
-    $this->drupalGet('admin/config/search/search_api');
+    $this->backdropGet('admin/config/search/search_api');
     $values = array(
       'server' => $this->serverId,
     );
-    $this->drupalPost("admin/config/search/search_api/index/{$this->indexId}/edit", $values, 'Save settings');
+    $this->backdropPost("admin/config/search/search_api/index/{$this->indexId}/edit", $values, 'Save settings');
     $this->clickLink(t('enable'));
 
     // Enable meta tags for the 'page' content type.
@@ -118,18 +118,18 @@ class MetatagCoreWithSearchAPITest extends MetatagTestHelper {
    */
   public function testAlter() {
     // Add a node with keywords.
-    $node = $this->drupalCreateNode();
+    $node = $this->backdropCreateNode();
     $keywords = 'puppies, rainbows';
     $values = array(
       'metatags[' . LANGUAGE_NONE . '][keywords][value]' => $keywords,
     );
-    $this->drupalPost('node/' . $node->nid . '/edit', $values, 'Save');
+    $this->backdropPost('node/' . $node->nid . '/edit', $values, 'Save');
 
     // Index the node.
-    $this->drupalPost("admin/config/search/search_api/index/{$this->indexId}", array(), 'Index now');
+    $this->backdropPost("admin/config/search/search_api/index/{$this->indexId}", array(), 'Index now');
 
     // Check whether the keywords have been indexed.
-    $this->assertIdentical(variable_get('metatag_search_test_keywords', FALSE), $keywords);
+    $this->assertIdentical(state_get('metatag_search_test_keywords', FALSE), $keywords);
   }
 
 }

--- a/tests/metatag_search_test.class.inc
+++ b/tests/metatag_search_test.class.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Dummy Search API service class.
+ */
+class MetatagSearchTestSearchApiService extends SearchApiAbstractService {
+
+  /**
+   * @inheritdoc
+   */
+  public function indexItems(SearchApiIndex $index, array $items) {
+    state_set('metatag_search_test_keywords', FALSE);
+    foreach (array_values($items) as $item) {
+      if (isset($item['metatag_keywords']['value'])) {
+        state_set('metatag_search_test_keywords', $item['metatag_keywords']['value']);
+      }
+    }
+    return array_keys($items);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function deleteItems($ids = 'all', SearchApiIndex $index = NULL) {}
+
+  /**
+   * @inheritdoc
+   */
+  public function search(SearchApiQueryInterface $query) {}
+
+}

--- a/tests/metatag_search_test.module
+++ b/tests/metatag_search_test.module
@@ -17,31 +17,10 @@ function metatag_search_test_search_api_service_info() {
 }
 
 /**
- * Dummy Search API service class.
+ * Implements hook_autoload_info().
  */
-class MetatagSearchTestSearchApiService extends SearchApiAbstractService {
-
-  /**
-   * @inheritdoc
-   */
-  public function indexItems(SearchApiIndex $index, array $items) {
-    variable_set('metatag_search_test_keywords', FALSE);
-    foreach (array_values($items) as $item) {
-      if (isset($item['metatag_keywords']['value'])) {
-        variable_set('metatag_search_test_keywords', $item['metatag_keywords']['value']);
-      }
-    }
-    return array_keys($items);
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public function deleteItems($ids = 'all', SearchApiIndex $index = NULL) {}
-
-  /**
-   * @inheritdoc
-   */
-  public function search(SearchApiQueryInterface $query) {}
-
+function metatag_search_test_autoload_info() {
+  return array(
+    'MetatagSearchTestSearchApiService' => 'metatag_search_test.class.inc',
+  );
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/metatag/issues/64.