### PR TITLE
Fixes #76 - missing name and label in new config

### DIFF
--- a/metatag.install
+++ b/metatag.install
@@ -549,16 +549,16 @@ function metatag_update_1004() {
  * Add name and label attributes to any config instances that don't have one
  */
 
- function metatag_update_1005() {
+function metatag_update_1005() {
   $files = config_get_names_with_prefix('metatag.instance');
   $configs = config_load_multiple($files);
   foreach ($configs as $filename => $config) {
     $instance = $config['instance'];
-    if (!isset($config['name']) ) {
+    if (!isset($config['name'])) {
       $name = str_replace(':', '.', $instance);
       config_set($filename, 'name', $name);
     }
-    if (!isset($config['label']) ) {
+    if (!isset($config['label'])) {
       config_set($filename, 'label', metatag_config_instance_label($instance));
     }
   }

--- a/metatag.install
+++ b/metatag.install
@@ -544,3 +544,22 @@ function metatag_update_1004() {
   }
   config_set('metatag.settings', 'enabled_tags', $enabled_tags);
 }
+
+/**
+ * Add name and label attributes to any config instances that don't have one
+ */
+
+ function metatag_update_1005() {
+  $files = config_get_names_with_prefix('metatag.instance');
+  $configs = config_load_multiple($files);
+  foreach ($configs as $filename => $config) {
+    $instance = $config['instance'];
+    if (!isset($config['name']) ) {
+      $name = str_replace(':', '.', $instance);
+      config_set($filename, 'name', $name);
+    }
+    if (!isset($config['label']) ) {
+      config_set($filename, 'label', metatag_config_instance_label($instance));
+    }
+  }
+ }

--- a/metatag.install
+++ b/metatag.install
@@ -548,7 +548,6 @@ function metatag_update_1004() {
 /**
  * Add name and label attributes to any config instances that don't have one
  */
-
 function metatag_update_1005() {
   $files = config_get_names_with_prefix('metatag.instance');
   $configs = config_load_multiple($files);

--- a/metatag.install
+++ b/metatag.install
@@ -563,4 +563,3 @@ function metatag_update_1005() {
     }
   }
  }
- 

--- a/metatag.install
+++ b/metatag.install
@@ -563,3 +563,4 @@ function metatag_update_1005() {
     }
   }
  }
+ 

--- a/metatag.module
+++ b/metatag.module
@@ -2147,6 +2147,7 @@ function metatag_preprocess_maintenance_page(&$variables) {
   if (defined('MAINTENANCE_MODE') && in_array(MAINTENANCE_MODE, array('install', 'update'))) {
     return;
   }
+  
   // Prepare all the tags, including doing token replacements.
   $metatags = metatag_prepare_tags();
   // Add each metatag to page header.

--- a/metatag.module
+++ b/metatag.module
@@ -365,6 +365,12 @@ function metatag_config_save($data) {
   if ($config->get('storage') == METATAG_STORAGE_DEFAULT) {
     $config->set('storage', METATAG_STORAGE_OVERRIDDEN);
   }
+  if ($config->get('name') == NULL) {
+    $config->set('name',$name);
+  }
+  if ($config->get('label') == NULL ) {
+    $config->set('label', metatag_config_instance_label($data['instance']));
+  }
 
   foreach ($data as $key => $value) {
     $config->set($key, $value);
@@ -2137,11 +2143,6 @@ function metatag_preprocess_page(&$variables) {
  * @see metatag_preprocess_page().
  */
 function metatag_preprocess_maintenance_page(&$variables) {
-  // Don't modify install or update pages.
-  if (defined('MAINTENANCE_MODE') && in_array(MAINTENANCE_MODE, array('install', 'update'))) {
-    return;
-  }
-
   // Prepare all the tags, including doing token replacements.
   $metatags = metatag_prepare_tags();
   // Add each metatag to page header.

--- a/metatag.module
+++ b/metatag.module
@@ -366,9 +366,9 @@ function metatag_config_save($data) {
     $config->set('storage', METATAG_STORAGE_OVERRIDDEN);
   }
   if ($config->get('name') == NULL) {
-    $config->set('name',$name);
+    $config->set('name', $name);
   }
-  if ($config->get('label') == NULL ) {
+  if ($config->get('label') == NULL) {
     $config->set('label', metatag_config_instance_label($data['instance']));
   }
 
@@ -2143,6 +2143,10 @@ function metatag_preprocess_page(&$variables) {
  * @see metatag_preprocess_page().
  */
 function metatag_preprocess_maintenance_page(&$variables) {
+  // Don't modify install or update pages.
+  if (defined('MAINTENANCE_MODE') && in_array(MAINTENANCE_MODE, array('install', 'update'))) {
+    return;
+  }
   // Prepare all the tags, including doing token replacements.
   $metatags = metatag_prepare_tags();
   // Add each metatag to page header.

--- a/metatag.module
+++ b/metatag.module
@@ -2147,7 +2147,7 @@ function metatag_preprocess_maintenance_page(&$variables) {
   if (defined('MAINTENANCE_MODE') && in_array(MAINTENANCE_MODE, array('install', 'update'))) {
     return;
   }
-  
+
   // Prepare all the tags, including doing token replacements.
   $metatags = metatag_prepare_tags();
   // Add each metatag to page header.

--- a/metatag_views/config/metatag.instance.view.json
+++ b/metatag_views/config/metatag.instance.view.json
@@ -1,6 +1,8 @@
 {
     "_config_name": "metatag.instance.view",
     "module": "metatag_views",
+    "name" : "view",
+    "label" : "Views",
     "storage": "default",
     "instance": "view",
     "api_version": 1,


### PR DESCRIPTION
Fixes #76 

This adds in `name` and `label` attributes for any new metatag config instances.
It also has an update hook to fix any existing metatag configs.