### PR TITLE
Issue #102: Adding MetatagSearchAlterCallback to autoloader.

### DIFF
--- a/metatag.module
+++ b/metatag.module
@@ -42,6 +42,10 @@ function metatag_autoload_info() {
     'BackdropTitleMetaTag' => 'metatag.inc',
     'BackdropListMetaTag' => 'metatag.inc',
     'BackdropDateIntervalMetaTag' => 'metatag.inc',
+
+    // Search API classes.
+    'MetatagSearchAlterCallback' => 'metatag.search_api.inc',
+
     // Tests.
     'MetatagTestHelper' => 'tests/metatag.helper.test',
     'MetatagCoreUnitTest' => 'tests/metatag.unit.test',

--- a/metatag.search_api.inc
+++ b/metatag.search_api.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Contains MetatagSearchAlterCallback.


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/metatag/issues/102