### PR TITLE
Issue #110: Add test coverage for canonical link.

### DIFF
--- a/metatag.inc
+++ b/metatag.inc
@@ -379,7 +379,10 @@ class BackdropTextMetaTag extends BackdropDefaultMetaTag {
 
 /**
  * Link type meta tag controller.
+ *
  * <link rel="canonical" href="https://moz.com/blog" />
+ *
+ * This can also add an HTTP "Link" header.
  */
 class BackdropLinkMetaTag extends BackdropTextMetaTag {
 

--- a/metatag.module
+++ b/metatag.module
@@ -2229,9 +2229,12 @@ function metatag_html_head_alter(&$elements) {
     // Examine the other meta tags to see if we have any duplicates.
     foreach ($closer_inspection as $key => $data) {
       // Check attributes.
-      if (isset($closer_inspection[$key]['#attributes'])) {
-        foreach ($closer_inspection[$key]['#attributes'] as $attr_key => $attr_value) {
-          $attr_value = strtolower($attr_value); // Account for G in generator.
+      if (isset($data['#attributes'])) {
+        foreach ($data['#attributes'] as $attr_key => $attr_value) {
+          // Account for "G" in "generator" in string comparisons.
+          if (is_string($attr_value)) {
+            $attr_value = strtolower($attr_value);
+          }
           // Only hide the metatag if it's one we care about.
           if (in_array($attr_key, $metatag_attrs) && in_array($attr_value, $core_tags)) {
             // Only hide metatag if another is provided.

--- a/tests/metatag.core_tag_removal.test
+++ b/tests/metatag.core_tag_removal.test
@@ -29,6 +29,9 @@ class MetatagCoreTagRemovalTest extends MetatagTestHelper {
     $this->assertEqual(count($xpath), 1, 'Exactly one generator meta tag found.');
     $this->assertEqual($xpath[0]['content'], $generator_global);
 
+    // Confirm the Generator tag is also added as an HTTP header.
+    $this->assertEqual($this->backdropGetHeader('X-Generator'), $generator_global, 'X-Generator HTTP header added.');
+
     // Update the global config to remove the 'generator' value.
     $config = metatag_config_load('global');
     unset($config['config']['generator']);
@@ -67,6 +70,9 @@ class MetatagCoreTagRemovalTest extends MetatagTestHelper {
     $xpath = $this->xpath("//meta[@name='Generator']");
     $this->assertEqual(count($xpath), 1, 'Exactly one generator meta tag found.');
     $this->assertEqual($xpath[0]['content'], $generator_core);
+
+    // Check that core's X-Generator header is the default.
+    $this->assertEqual($this->backdropGetHeader('X-Generator'), $generator_core, 'Default X-Generator HTTP header set.');
   }
 
 }

--- a/tests/metatag.node.test
+++ b/tests/metatag.node.test
@@ -129,6 +129,10 @@ class MetatagCoreNodeTest extends MetatagTestHelper {
     $this->assertEqual($xpath[0]['href'], $new_canonical);
     $this->assertNotEqual($xpath[0]['href'], $old_canonical);
 
+    // Confirm the canonical tag is also added as an HTTP header.
+    $http_link_header = "<$new_canonical>; rel=\"canonical\"";
+    $this->assertEqual($this->backdropGetHeader('Link'), $http_link_header, 'Canonical Link HTTP header set.');
+
     // Try loading the node revisions page.
     $this->backdropGet('node/' . $node->nid . '/revisions');
     // Verify the page did not load correctly. This is because the revisions


### PR DESCRIPTION
Related to https://github.com/backdrop-contrib/metatag/issues/110.

Adds test coverage for checking the canonical `Link` HTTP header is added. Avoiding errors when `#attribtues` use a non-string value as can happen with `schema_metatag`.